### PR TITLE
Add shebang to bump.js and update package.json version

### DIFF
--- a/bump.js
+++ b/bump.js
@@ -1,3 +1,5 @@
+#!/usr/bin/env node
+
 const fs = require("node:fs");
 const path = require("node:path");
 const chronoversion = require("chronoversion").default;

--- a/package.json
+++ b/package.json
@@ -1,12 +1,13 @@
 {
   "name": "chronobump",
-  "version": "2025.1.1",
+  "version": "2025.1.2",
   "main": "bump.js",
+  "bin": "bump.js",
   "scripts": {
     "bump": "node bump.js",
     "lint": "npx @biomejs/biome check bump.js",
     "lint:fix": "npm run lint -- --write",
-    "generate-todo": "leasot -x --reporter markdown 'src/**/*.{js,jsx,ts,tsx,css}' > TODO.md",
+    "generate-todo": "leasot -x --reporter markdown '*.{js,jsx,ts,tsx,css}' > TODO.md",
     "prepare": "husky"
   },
   "keywords": [


### PR DESCRIPTION
Include a shebang in bump.js for execution as a script and update the package version to 2025.1.2. Adjust the bin entry in package.json accordingly.

## Summary by Sourcery

Update Chronobump to version 2025.1.2 and allow direct execution.

Chores:
- Add shebang to `bump.js` to enable execution as a script.
- Update the `bin` entry in `package.json` to point to `bump.js`.
- Modify the `generate-todo` script in `package.json` to only include files in the root directory.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added a version bump script for managing package versions
	- Expanded file search scope for generating TODO list

- **Chores**
	- Updated package version from 2025.1.1 to 2025.1.2
	- Added binary configuration for the new bump script

<!-- end of auto-generated comment: release notes by coderabbit.ai -->