### PR TITLE
Fix path resolution in updatePackageVersion function

### DIFF
--- a/bump.js
+++ b/bump.js
@@ -20,6 +20,14 @@ function updatePackageVersion() {
   const packageJsonPath = path.resolve(process.cwd(), "package.json");
   const packageLockJsonPath = path.resolve(process.cwd(), "package-lock.json");
 
+  if (!fs.existsSync(packageJsonPath)) {
+    throw new Error("package.json not found in the current directory");
+  }
+
+  if (!fs.existsSync(packageLockJsonPath)) {
+    throw new Error("package-lock.json not found in the current directory");
+  }
+
   let packageJson;
   let packageLockJson;
 

--- a/bump.js
+++ b/bump.js
@@ -17,8 +17,8 @@ const chronoversion = require("chronoversion").default;
  * @returns {void}
  */
 function updatePackageVersion() {
-  const packageJsonPath = path.resolve(__dirname, "package.json");
-  const packageLockJsonPath = path.resolve(__dirname, "package-lock.json");
+  const packageJsonPath = path.resolve(process.cwd(), "package.json");
+  const packageLockJsonPath = path.resolve(process.cwd(), "package-lock.json");
 
   let packageJson;
   let packageLockJson;

--- a/bump.js
+++ b/bump.js
@@ -11,6 +11,9 @@ const chronoversion = require("chronoversion").default;
  * generates a new version using the getVersion function, and writes the updated
  * version back to both files.
  *
+ * @description The script looks for package files in the current working directory
+ * from where the script is executed.
+ *
  * @throws {Error} If unable to read or parse package.json or package-lock.json
  * @throws {Error} If unable to write updated package.json or package-lock.json
  *


### PR DESCRIPTION
Update the path resolution in the `updatePackageVersion` function to use `process.cwd()` for correct file location.

## Summary by Sourcery

Bug Fixes:
- Resolve "package.json" and "package-lock.json" files using process.cwd() to ensure correct file paths are used during version updates.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated file path resolution mechanism for package management scripts
	- Improved script flexibility for working with package configuration files across different directories

<!-- end of auto-generated comment: release notes by coderabbit.ai -->